### PR TITLE
fix: change meta params in CallToolRequest to match upstream changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# Go binary
+bin/
+
 # Go workspace file
 go.work
 go.work.sum

--- a/tools/deployment_test.go
+++ b/tools/deployment_test.go
@@ -111,11 +111,9 @@ func TestDescribeDeploymentHandler(t *testing.T) {
 
 			request := mcp.CallToolRequest{
 				Params: struct {
-					Name      string                 `json:"name"`
-					Arguments map[string]interface{} `json:"arguments,omitempty"`
-					Meta      *struct {
-						ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-					} `json:"_meta,omitempty"`
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+					Meta      *mcp.Meta      `json:"_meta,omitempty"`
 				}{
 					Arguments: tc.args,
 				},
@@ -296,11 +294,9 @@ func TestUpdateDeploymentHandler(t *testing.T) {
 
 			request := mcp.CallToolRequest{
 				Params: struct {
-					Name      string                 `json:"name"`
-					Arguments map[string]interface{} `json:"arguments,omitempty"`
-					Meta      *struct {
-						ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-					} `json:"_meta,omitempty"`
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+					Meta      *mcp.Meta      `json:"_meta,omitempty"`
 				}{
 					Arguments: tc.args,
 				},

--- a/tools/pod_test.go
+++ b/tools/pod_test.go
@@ -233,11 +233,9 @@ func TestCreatePodHandler(t *testing.T) {
 
 			request := mcp.CallToolRequest{
 				Params: struct {
-					Name      string                 `json:"name"`
-					Arguments map[string]interface{} `json:"arguments,omitempty"`
-					Meta      *struct {
-						ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-					} `json:"_meta,omitempty"`
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+					Meta      *mcp.Meta      `json:"_meta,omitempty"`
 				}{
 					Arguments: tc.args,
 				},
@@ -344,11 +342,9 @@ func TestListPodsHandler(t *testing.T) {
 
 			request := mcp.CallToolRequest{
 				Params: struct {
-					Name      string                 `json:"name"`
-					Arguments map[string]interface{} `json:"arguments,omitempty"`
-					Meta      *struct {
-						ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-					} `json:"_meta,omitempty"`
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+					Meta      *mcp.Meta      `json:"_meta,omitempty"`
 				}{
 					Arguments: tc.args,
 				},
@@ -443,11 +439,9 @@ func TestGetPodHandler(t *testing.T) {
 
 			request := mcp.CallToolRequest{
 				Params: struct {
-					Name      string                 `json:"name"`
-					Arguments map[string]interface{} `json:"arguments,omitempty"`
-					Meta      *struct {
-						ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-					} `json:"_meta,omitempty"`
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+					Meta      *mcp.Meta      `json:"_meta,omitempty"`
 				}{
 					Arguments: tc.args,
 				},
@@ -550,11 +544,9 @@ func TestDeletePodHandler(t *testing.T) {
 
 			request := mcp.CallToolRequest{
 				Params: struct {
-					Name      string                 `json:"name"`
-					Arguments map[string]interface{} `json:"arguments,omitempty"`
-					Meta      *struct {
-						ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-					} `json:"_meta,omitempty"`
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+					Meta      *mcp.Meta      `json:"_meta,omitempty"`
 				}{
 					Arguments: tc.args,
 				},
@@ -654,11 +646,9 @@ func TestStreamLogsHandler(t *testing.T) {
 
 			request := mcp.CallToolRequest{
 				Params: struct {
-					Name      string                 `json:"name"`
-					Arguments map[string]interface{} `json:"arguments,omitempty"`
-					Meta      *struct {
-						ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-					} `json:"_meta,omitempty"`
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+					Meta      *mcp.Meta      `json:"_meta,omitempty"`
 				}{
 					Arguments: tc.args,
 				},

--- a/tools/service_test.go
+++ b/tools/service_test.go
@@ -153,11 +153,9 @@ func TestListServicesHandler(t *testing.T) {
 
 			request := mcp.CallToolRequest{
 				Params: struct {
-					Name      string                 `json:"name"`
-					Arguments map[string]interface{} `json:"arguments,omitempty"`
-					Meta      *struct {
-						ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-					} `json:"_meta,omitempty"`
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+					Meta      *mcp.Meta      `json:"_meta,omitempty"`
 				}{
 					Arguments: tc.args,
 				},
@@ -254,11 +252,9 @@ func TestGetServiceHandler(t *testing.T) {
 
 			request := mcp.CallToolRequest{
 				Params: struct {
-					Name      string                 `json:"name"`
-					Arguments map[string]interface{} `json:"arguments,omitempty"`
-					Meta      *struct {
-						ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-					} `json:"_meta,omitempty"`
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+					Meta      *mcp.Meta      `json:"_meta,omitempty"`
 				}{
 					Arguments: tc.args,
 				},
@@ -590,11 +586,9 @@ func TestCreateServiceHandler(t *testing.T) {
 
 			request := mcp.CallToolRequest{
 				Params: struct {
-					Name      string                 `json:"name"`
-					Arguments map[string]interface{} `json:"arguments,omitempty"`
-					Meta      *struct {
-						ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-					} `json:"_meta,omitempty"`
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+					Meta      *mcp.Meta      `json:"_meta,omitempty"`
 				}{
 					Arguments: tc.args,
 				},
@@ -831,11 +825,9 @@ func TestDeleteServiceHandler(t *testing.T) {
 
 			request := mcp.CallToolRequest{
 				Params: struct {
-					Name      string                 `json:"name"`
-					Arguments map[string]interface{} `json:"arguments,omitempty"`
-					Meta      *struct {
-						ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-					} `json:"_meta,omitempty"`
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+					Meta      *mcp.Meta      `json:"_meta,omitempty"`
 				}{
 					Arguments: tc.args,
 				},


### PR DESCRIPTION
# Description

Change `mcp.CallToolRequest` Meta params to match the upstream breaking change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules