### PR TITLE
chore: use previous version definition for new code in sonar scan ui …

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,6 @@ sonar.sourceEncoding=UTF-8
 sonar.projectKey=basebandit_kai
 sonar.organization=basebandit
 sonar.projectName=kai
-sonar.projectVersion=0.0.1
 
 sonar.sources=.
 sonar.exclusions=**/*_test.go,**/testmocks/**


### PR DESCRIPTION
…settings

# Description

- When merging PR to main the sonarscan job on main reports duplicate false positive warnings. This PR removes the hardcoded `sonar.projectVersion` and  instead relies on the set definition of NewCode in the sonar scan UI which is set to `previous_version`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules