### PR TITLE
feat(transport): add Streamable HTTP transport at /mcp

### DIFF
--- a/cluster/formatted.go
+++ b/cluster/formatted.go
@@ -393,27 +393,27 @@ func formatServiceList(services *corev1.ServiceList, includeNamespace bool) stri
 
 		// Format the output
 		if includeNamespace {
-			result.WriteString(fmt.Sprintf("• %s/%s: Type=%s, ClusterIP=%s, ExternalIP=%s, Ports=%s, Age=%s\n",
+			fmt.Fprintf(&result, "• %s/%s: Type=%s, ClusterIP=%s, ExternalIP=%s, Ports=%s, Age=%s\n",
 				svc.Namespace,
 				svc.Name,
 				serviceType,
 				clusterIP,
 				externalIP,
 				portsStr,
-				formatDuration(age)))
+				formatDuration(age))
 		} else {
-			result.WriteString(fmt.Sprintf("• %s: Type=%s, ClusterIP=%s, ExternalIP=%s, Ports=%s, Age=%s\n",
+			fmt.Fprintf(&result, "• %s: Type=%s, ClusterIP=%s, ExternalIP=%s, Ports=%s, Age=%s\n",
 				svc.Name,
 				serviceType,
 				clusterIP,
 				externalIP,
 				portsStr,
-				formatDuration(age)))
+				formatDuration(age))
 		}
 	}
 
 	// Add total count
-	result.WriteString(fmt.Sprintf("\nTotal: %d service(s)", len(services.Items)))
+	fmt.Fprintf(&result, "\nTotal: %d service(s)", len(services.Items))
 
 	return result.String()
 }
@@ -612,7 +612,7 @@ func formatNamespaceList(namespaces *corev1.NamespaceList, labelSelector string)
 	var result strings.Builder
 
 	if labelSelector != "" {
-		result.WriteString(fmt.Sprintf("Namespaces matching label selector '%s':\n", labelSelector))
+		fmt.Fprintf(&result, "Namespaces matching label selector '%s':\n", labelSelector)
 	} else {
 		result.WriteString("Namespaces:\n")
 	}
@@ -624,18 +624,18 @@ func formatNamespaceList(namespaces *corev1.NamespaceList, labelSelector string)
 			status = "Active"
 		}
 
-		result.WriteString(fmt.Sprintf("• %s: Status=%s, Age=%s",
-			ns.Name, status, formatDuration(age)))
+		fmt.Fprintf(&result, "• %s: Status=%s, Age=%s",
+			ns.Name, status, formatDuration(age))
 
 		if len(ns.Labels) > 0 {
 			labelCount := len(ns.Labels)
-			result.WriteString(fmt.Sprintf(" - Labels: %d", labelCount))
+			fmt.Fprintf(&result, " - Labels: %d", labelCount)
 		}
 
 		result.WriteString("\n")
 	}
 
-	result.WriteString(fmt.Sprintf("\nTotal: %d namespace(s)", len(namespaces.Items)))
+	fmt.Fprintf(&result, "\nTotal: %d namespace(s)", len(namespaces.Items))
 
 	return result.String()
 }
@@ -688,21 +688,21 @@ func formatConfigMapList(configMaps *corev1.ConfigMapList, includeNamespace bool
 		dataCount := len(cm.Data) + len(cm.BinaryData)
 
 		if includeNamespace {
-			result.WriteString(fmt.Sprintf("• %s/%s: Data=%d, Age=%s",
-				cm.Namespace, cm.Name, dataCount, formatDuration(age)))
+			fmt.Fprintf(&result, "• %s/%s: Data=%d, Age=%s",
+				cm.Namespace, cm.Name, dataCount, formatDuration(age))
 		} else {
-			result.WriteString(fmt.Sprintf("• %s: Data=%d, Age=%s",
-				cm.Name, dataCount, formatDuration(age)))
+			fmt.Fprintf(&result, "• %s: Data=%d, Age=%s",
+				cm.Name, dataCount, formatDuration(age))
 		}
 
 		if len(cm.Labels) > 0 {
-			result.WriteString(fmt.Sprintf(" - Labels: %d", len(cm.Labels)))
+			fmt.Fprintf(&result, " - Labels: %d", len(cm.Labels))
 		}
 
 		result.WriteString("\n")
 	}
 
-	result.WriteString(fmt.Sprintf("\nTotal: %d ConfigMap(s)", len(configMaps.Items)))
+	fmt.Fprintf(&result, "\nTotal: %d ConfigMap(s)", len(configMaps.Items))
 
 	return result.String()
 }
@@ -745,21 +745,21 @@ func formatSecretList(secrets *corev1.SecretList, includeNamespace bool) string 
 		dataCount := len(secret.Data)
 
 		if includeNamespace {
-			result.WriteString(fmt.Sprintf("• %s/%s: Type=%s, Data=%d, Age=%s",
-				secret.Namespace, secret.Name, secret.Type, dataCount, formatDuration(age)))
+			fmt.Fprintf(&result, "• %s/%s: Type=%s, Data=%d, Age=%s",
+				secret.Namespace, secret.Name, secret.Type, dataCount, formatDuration(age))
 		} else {
-			result.WriteString(fmt.Sprintf("• %s: Type=%s, Data=%d, Age=%s",
-				secret.Name, secret.Type, dataCount, formatDuration(age)))
+			fmt.Fprintf(&result, "• %s: Type=%s, Data=%d, Age=%s",
+				secret.Name, secret.Type, dataCount, formatDuration(age))
 		}
 
 		if len(secret.Labels) > 0 {
-			result.WriteString(fmt.Sprintf(" - Labels: %d", len(secret.Labels)))
+			fmt.Fprintf(&result, " - Labels: %d", len(secret.Labels))
 		}
 
 		result.WriteString("\n")
 	}
 
-	result.WriteString(fmt.Sprintf("\nTotal: %d Secret(s)", len(secrets.Items)))
+	fmt.Fprintf(&result, "\nTotal: %d Secret(s)", len(secrets.Items))
 
 	return result.String()
 }
@@ -812,7 +812,7 @@ func formatJobList(jobs *batchv1.JobList, includeNamespace bool) string {
 	if includeNamespace {
 		result.WriteString("Jobs across all namespaces:\n")
 	} else {
-		result.WriteString(fmt.Sprintf("Jobs in namespace %q:\n", jobs.Items[0].Namespace))
+		fmt.Fprintf(&result, "Jobs in namespace %q:\n", jobs.Items[0].Namespace)
 	}
 
 	for _, job := range jobs.Items {
@@ -832,21 +832,21 @@ func formatJobList(jobs *batchv1.JobList, includeNamespace bool) string {
 		}
 
 		if includeNamespace {
-			result.WriteString(fmt.Sprintf("• %s/%s: %s - Age: %s",
-				job.Namespace, job.Name, status, formatDuration(age)))
+			fmt.Fprintf(&result, "• %s/%s: %s - Age: %s",
+				job.Namespace, job.Name, status, formatDuration(age))
 		} else {
-			result.WriteString(fmt.Sprintf("• %s: %s - Age: %s",
-				job.Name, status, formatDuration(age)))
+			fmt.Fprintf(&result, "• %s: %s - Age: %s",
+				job.Name, status, formatDuration(age))
 		}
 
 		if len(job.Labels) > 0 {
-			result.WriteString(fmt.Sprintf(" - Labels: %d", len(job.Labels)))
+			fmt.Fprintf(&result, " - Labels: %d", len(job.Labels))
 		}
 
 		result.WriteString("\n")
 	}
 
-	result.WriteString(fmt.Sprintf("\nTotal: %d Job(s)", len(jobs.Items)))
+	fmt.Fprintf(&result, "\nTotal: %d Job(s)", len(jobs.Items))
 
 	return result.String()
 }
@@ -946,7 +946,7 @@ func formatCronJobList(cronJobs *batchv1.CronJobList, includeNamespace bool) str
 		result.WriteString("CronJobs across all namespaces:\n")
 	} else {
 		if len(cronJobs.Items) > 0 {
-			result.WriteString(fmt.Sprintf("CronJobs in namespace %q:\n", cronJobs.Items[0].Namespace))
+			fmt.Fprintf(&result, "CronJobs in namespace %q:\n", cronJobs.Items[0].Namespace)
 		} else {
 			result.WriteString("CronJobs in namespace:\n")
 		}
@@ -966,21 +966,21 @@ func formatCronJobList(cronJobs *batchv1.CronJobList, includeNamespace bool) str
 		}
 
 		if includeNamespace {
-			result.WriteString(fmt.Sprintf("• %s/%s: Schedule=%s, %s, LastSchedule=%s, Active=%d, Age=%s",
-				cronJob.Namespace, cronJob.Name, cronJob.Spec.Schedule, suspended, lastSchedule, len(cronJob.Status.Active), formatDuration(age)))
+			fmt.Fprintf(&result, "• %s/%s: Schedule=%s, %s, LastSchedule=%s, Active=%d, Age=%s",
+				cronJob.Namespace, cronJob.Name, cronJob.Spec.Schedule, suspended, lastSchedule, len(cronJob.Status.Active), formatDuration(age))
 		} else {
-			result.WriteString(fmt.Sprintf("• %s: Schedule=%s, %s, LastSchedule=%s, Active=%d, Age=%s",
-				cronJob.Name, cronJob.Spec.Schedule, suspended, lastSchedule, len(cronJob.Status.Active), formatDuration(age)))
+			fmt.Fprintf(&result, "• %s: Schedule=%s, %s, LastSchedule=%s, Active=%d, Age=%s",
+				cronJob.Name, cronJob.Spec.Schedule, suspended, lastSchedule, len(cronJob.Status.Active), formatDuration(age))
 		}
 
 		if len(cronJob.Labels) > 0 {
-			result.WriteString(fmt.Sprintf(" - Labels: %d", len(cronJob.Labels)))
+			fmt.Fprintf(&result, " - Labels: %d", len(cronJob.Labels))
 		}
 
 		result.WriteString("\n")
 	}
 
-	result.WriteString(fmt.Sprintf("\nTotal: %d CronJob(s)", len(cronJobs.Items)))
+	fmt.Fprintf(&result, "\nTotal: %d CronJob(s)", len(cronJobs.Items))
 
 	return result.String()
 }
@@ -1095,7 +1095,7 @@ func formatIngressList(ingresses *networkingv1.IngressList, includeNamespace boo
 		result.WriteString("Ingresses across all namespaces:\n")
 	} else {
 		if len(ingresses.Items) > 0 {
-			result.WriteString(fmt.Sprintf("Ingresses in namespace %q:\n", ingresses.Items[0].Namespace))
+			fmt.Fprintf(&result, "Ingresses in namespace %q:\n", ingresses.Items[0].Namespace)
 		} else {
 			result.WriteString("Ingresses in namespace:\n")
 		}
@@ -1134,11 +1134,11 @@ func formatIngressList(ingresses *networkingv1.IngressList, includeNamespace boo
 		}
 
 		if includeNamespace {
-			result.WriteString(fmt.Sprintf("• %s/%s: Class=%s, Hosts=%s, Address=%s, Age=%s",
-				ingress.Namespace, ingress.Name, ingressClass, hostStr, address, formatDuration(age)))
+			fmt.Fprintf(&result, "• %s/%s: Class=%s, Hosts=%s, Address=%s, Age=%s",
+				ingress.Namespace, ingress.Name, ingressClass, hostStr, address, formatDuration(age))
 		} else {
-			result.WriteString(fmt.Sprintf("• %s: Class=%s, Hosts=%s, Address=%s, Age=%s",
-				ingress.Name, ingressClass, hostStr, address, formatDuration(age)))
+			fmt.Fprintf(&result, "• %s: Class=%s, Hosts=%s, Address=%s, Age=%s",
+				ingress.Name, ingressClass, hostStr, address, formatDuration(age))
 		}
 
 		// TLS indicator
@@ -1147,13 +1147,13 @@ func formatIngressList(ingresses *networkingv1.IngressList, includeNamespace boo
 		}
 
 		if len(ingress.Labels) > 0 {
-			result.WriteString(fmt.Sprintf(" - Labels: %d", len(ingress.Labels)))
+			fmt.Fprintf(&result, " - Labels: %d", len(ingress.Labels))
 		}
 
 		result.WriteString("\n")
 	}
 
-	result.WriteString(fmt.Sprintf("\nTotal: %d Ingress(es)", len(ingresses.Items)))
+	fmt.Fprintf(&result, "\nTotal: %d Ingress(es)", len(ingresses.Items))
 
 	return result.String()
 }

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -32,17 +32,43 @@ type Manager struct {
 	contexts         map[string]*kai.ContextInfo
 	currentContext   string
 	currentNamespace string
+	requestTimeout   time.Duration
 }
 
-// New creates a new cluster Manager
-func New() *Manager {
-	return &Manager{
+// Option configures a Manager.
+type Option func(*Manager)
+
+// WithRequestTimeout sets the per-request timeout applied to every Kubernetes
+// API client created by the Manager. Zero or negative values are ignored and
+// the 30 s default is kept.
+func WithRequestTimeout(d time.Duration) Option {
+	return func(cm *Manager) {
+		if d > 0 {
+			cm.requestTimeout = d
+		}
+	}
+}
+
+// New creates a new cluster Manager. Without options the default request
+// timeout is 30 seconds.
+func New(opts ...Option) *Manager {
+	cm := &Manager{
 		kubeconfigs:      make(map[string]string),
 		clients:          make(map[string]kubernetes.Interface),
 		dynamicClients:   make(map[string]dynamic.Interface),
 		contexts:         make(map[string]*kai.ContextInfo),
 		currentNamespace: "default",
+		requestTimeout:   30 * time.Second,
 	}
+	for _, opt := range opts {
+		opt(cm)
+	}
+	return cm
+}
+
+// RequestTimeout returns the per-request timeout configured on this Manager.
+func (cm *Manager) RequestTimeout() time.Duration {
+	return cm.requestTimeout
 }
 
 // LoadKubeConfig loads a kubeconfig file into the manager
@@ -69,7 +95,7 @@ func (cm *Manager) LoadKubeConfig(name, path string) error {
 		return err
 	}
 
-	clientset, dynamicClient, err := createClients(resolvedPath)
+	clientset, dynamicClient, err := cm.createClients(resolvedPath)
 	if err != nil {
 		return err
 	}
@@ -406,14 +432,16 @@ func (cm *Manager) updateKubeconfigCurrentContext(contextName, configPath string
 	return nil
 }
 
-// createClients creates Kubernetes clients from the kubeconfig file
-func createClients(path string) (kubernetes.Interface, dynamic.Interface, error) {
+// createClients builds Kubernetes typed and dynamic clients from a kubeconfig
+// path. The per-request timeout is taken from the Manager so the user-facing
+// --request-timeout flag is honored end-to-end.
+func (cm *Manager) createClients(path string) (kubernetes.Interface, dynamic.Interface, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error building config from flags: %w", err)
 	}
 
-	config.Timeout = 30 * time.Second
+	config.Timeout = cm.requestTimeout
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/cmd/kai/main.go
+++ b/cmd/kai/main.go
@@ -42,8 +42,8 @@ func main() {
 
 	flag.StringVar(&kubeconfig, "kubeconfig", defaultKubeconfig, "Path to kubeconfig file")
 	flag.StringVar(&contextName, "context", "local", "Name for the loaded context")
-	flag.StringVar(&transport, "transport", "stdio", "Transport mode: stdio (default) or sse")
-	flag.StringVar(&sseAddr, "sse-addr", ":8080", "Address for SSE server (only used with -transport=sse)")
+	flag.StringVar(&transport, "transport", "stdio", "Transport mode: stdio (default), streamable-http, or sse-legacy. \"sse\" is accepted as a deprecated alias of \"sse-legacy\".")
+	flag.StringVar(&sseAddr, "sse-addr", ":8080", "Address for the HTTP listener (used with streamable-http or sse-legacy). The flag name is kept for backwards compatibility.")
 	flag.StringVar(&logFormat, "log-format", "json", "Log format: json (default) or text")
 	flag.StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
 	flag.StringVar(&tlsCert, "tls-cert", "", "Path to TLS certificate file (enables HTTPS for SSE)")
@@ -105,17 +105,28 @@ func main() {
 
 	go func() {
 		switch transport {
-		case "sse":
+		case "streamable-http", "http":
 			logger.Info("starting server",
-				slog.String("transport", "sse"),
+				slog.String("transport", "streamable-http"),
+				slog.String("address", sseAddr),
+			)
+			errChan <- s.ServeStreamableHTTP(sseAddr)
+		case "sse":
+			logger.Warn("transport \"sse\" is deprecated; use \"sse-legacy\" or migrate to \"streamable-http\"")
+			fallthrough
+		case "sse-legacy":
+			logger.Info("starting server",
+				slog.String("transport", "sse-legacy"),
 				slog.String("address", sseAddr),
 			)
 			errChan <- s.ServeSSE(sseAddr)
-		default:
+		case "stdio", "":
 			logger.Info("starting server",
 				slog.String("transport", "stdio"),
 			)
 			errChan <- s.Serve()
+		default:
+			errChan <- fmt.Errorf("unknown transport %q (valid: stdio, streamable-http, sse-legacy)", transport)
 		}
 	}()
 

--- a/cmd/kai/main.go
+++ b/cmd/kai/main.go
@@ -63,7 +63,7 @@ func main() {
 	}
 
 	// Initialize cluster manager
-	cm := cluster.New()
+	cm := cluster.New(cluster.WithRequestTimeout(requestTimeout))
 
 	if err := cm.LoadKubeConfig(contextName, kubeconfig); err != nil {
 		logger.Error("failed to load kubeconfig",

--- a/server.go
+++ b/server.go
@@ -168,47 +168,81 @@ func (s *Server) Serve() error {
 	return server.ServeStdio(s.mcpServer)
 }
 
-// ServeSSE starts the server using SSE transport (for web clients)
+// ServeStreamableHTTP starts the server using the Streamable HTTP transport
+// (MCP spec 2025-03-26). The MCP endpoint is exposed at /mcp; health, ready,
+// and metrics endpoints are served from the same listener.
+func (s *Server) ServeStreamableHTTP(addr string) error {
+	streamSrv := server.NewStreamableHTTPServer(s.mcpServer)
+
+	mux := http.NewServeMux()
+	s.registerOpsEndpoints(mux)
+
+	mux.Handle("/mcp", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		activeConnections.Inc()
+		defer activeConnections.Dec()
+		streamSrv.ServeHTTP(w, r)
+	}))
+
+	slog.Info("streamable-http server endpoints",
+		slog.String("mcp", fmt.Sprintf("http://%s/mcp", addr)),
+		slog.String("health", fmt.Sprintf("http://%s/healthz", addr)),
+		slog.String("ready", fmt.Sprintf("http://%s/readyz", addr)),
+		slog.String("metrics", fmt.Sprintf("http://%s/metrics", addr)),
+	)
+
+	return s.runHTTP(addr, mux)
+}
+
+// ServeSSE starts the server using the legacy HTTP+SSE transport (MCP spec
+// 2024-11-05). Kept for compatibility with older clients; new deployments
+// should use ServeStreamableHTTP.
 func (s *Server) ServeSSE(addr string) error {
 	sseServer := server.NewSSEServer(s.mcpServer)
 
 	mux := http.NewServeMux()
+	s.registerOpsEndpoints(mux)
 
-	// Health check endpoints
-	mux.HandleFunc("/healthz", s.healthzHandler)
-	mux.HandleFunc("/readyz", s.readyzHandler)
-
-	// Metrics endpoint
-	if s.cfg.metricsEnabled {
-		mux.Handle("/metrics", promhttp.Handler())
-	}
-
-	// SSE endpoint
 	mux.Handle("/sse", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		activeConnections.Inc()
 		defer activeConnections.Dec()
 		sseServer.ServeHTTP(w, r)
 	}))
-
-	// Message endpoint for SSE
 	mux.Handle("/message", sseServer)
 
-	s.httpServer = &http.Server{
-		Addr:         addr,
-		Handler:      mux,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 0, // SSE requires no write timeout
-		IdleTimeout:  60 * time.Second,
-	}
-
-	s.SetReady(true)
-
-	slog.Info("SSE server endpoints",
+	slog.Info("sse-legacy server endpoints",
 		slog.String("sse", fmt.Sprintf("http://%s/sse", addr)),
 		slog.String("health", fmt.Sprintf("http://%s/healthz", addr)),
 		slog.String("ready", fmt.Sprintf("http://%s/readyz", addr)),
 		slog.String("metrics", fmt.Sprintf("http://%s/metrics", addr)),
 	)
+
+	return s.runHTTP(addr, mux)
+}
+
+// registerOpsEndpoints wires the health, readiness, and metrics endpoints
+// shared by every HTTP-based transport.
+func (s *Server) registerOpsEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/healthz", s.healthzHandler)
+	mux.HandleFunc("/readyz", s.readyzHandler)
+	if s.cfg.metricsEnabled {
+		mux.Handle("/metrics", promhttp.Handler())
+	}
+}
+
+// runHTTP builds the http.Server, marks the server ready, and starts
+// listening. WriteTimeout is intentionally zero because both Streamable HTTP
+// (chunked SSE responses) and the legacy SSE transport keep connections
+// open indefinitely.
+func (s *Server) runHTTP(addr string, handler http.Handler) error {
+	s.httpServer = &http.Server{
+		Addr:         addr,
+		Handler:      handler,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 0,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	s.SetReady(true)
 
 	if s.cfg.tlsCertFile != "" && s.cfg.tlsKeyFile != "" {
 		slog.Info("TLS enabled",

--- a/tools/context.go
+++ b/tools/context.go
@@ -100,14 +100,14 @@ func listContextsHandler(cm kai.ClusterManager) func(ctx context.Context, reques
 				marker = "*"
 			}
 
-			result.WriteString(fmt.Sprintf("%s %s\n", marker, contextInfo.Name))
-			result.WriteString(fmt.Sprintf("  Cluster: %s\n", contextInfo.Cluster))
-			result.WriteString(fmt.Sprintf("  User: %s\n", contextInfo.User))
-			result.WriteString(fmt.Sprintf("  Namespace: %s\n", contextInfo.Namespace))
+			fmt.Fprintf(&result, "%s %s\n", marker, contextInfo.Name)
+			fmt.Fprintf(&result, "  Cluster: %s\n", contextInfo.Cluster)
+			fmt.Fprintf(&result, "  User: %s\n", contextInfo.User)
+			fmt.Fprintf(&result, "  Namespace: %s\n", contextInfo.Namespace)
 			result.WriteString("\n")
 		}
 
-		result.WriteString(fmt.Sprintf("Total: %d context(s)", len(contexts)))
+		fmt.Fprintf(&result, "Total: %d context(s)", len(contexts))
 
 		return mcp.NewToolResultText(result.String()), nil
 	}
@@ -265,18 +265,18 @@ func describeContextHandler(cm kai.ClusterManager) func(ctx context.Context, req
 		}
 
 		var result strings.Builder
-		result.WriteString(fmt.Sprintf("Context: %s\n", contextInfo.Name))
-		result.WriteString(fmt.Sprintf("Cluster: %s\n", contextInfo.Cluster))
-		result.WriteString(fmt.Sprintf("User: %s\n", contextInfo.User))
-		result.WriteString(fmt.Sprintf("Namespace: %s\n", contextInfo.Namespace))
-		result.WriteString(fmt.Sprintf("Server: %s\n", contextInfo.ServerURL))
-		result.WriteString(fmt.Sprintf("Config Path: %s\n", contextInfo.ConfigPath))
+		fmt.Fprintf(&result, "Context: %s\n", contextInfo.Name)
+		fmt.Fprintf(&result, "Cluster: %s\n", contextInfo.Cluster)
+		fmt.Fprintf(&result, "User: %s\n", contextInfo.User)
+		fmt.Fprintf(&result, "Namespace: %s\n", contextInfo.Namespace)
+		fmt.Fprintf(&result, "Server: %s\n", contextInfo.ServerURL)
+		fmt.Fprintf(&result, "Config Path: %s\n", contextInfo.ConfigPath)
 
 		status := "inactive"
 		if contextInfo.IsActive {
 			status = "active"
 		}
-		result.WriteString(fmt.Sprintf("Status: %s", status))
+		fmt.Fprintf(&result, "Status: %s", status)
 
 		return mcp.NewToolResultText(result.String()), nil
 	}

--- a/tools/operations.go
+++ b/tools/operations.go
@@ -200,15 +200,15 @@ func formatPortForwardSession(session *cluster.PortForwardSession) string {
 	var sb strings.Builder
 	sb.WriteString("Port forward started successfully\n")
 	sb.WriteString(strings.Repeat("-", 40) + "\n")
-	sb.WriteString(fmt.Sprintf("Session ID: %s\n", session.ID))
-	sb.WriteString(fmt.Sprintf("Namespace:  %s\n", session.Namespace))
-	sb.WriteString(fmt.Sprintf("Target:     %s/%s\n", session.TargetType, session.Target))
+	fmt.Fprintf(&sb, "Session ID: %s\n", session.ID)
+	fmt.Fprintf(&sb, "Namespace:  %s\n", session.Namespace)
+	fmt.Fprintf(&sb, "Target:     %s/%s\n", session.TargetType, session.Target)
 	if session.TargetType == "service" {
-		sb.WriteString(fmt.Sprintf("Pod:        %s\n", session.PodName))
+		fmt.Fprintf(&sb, "Pod:        %s\n", session.PodName)
 	}
-	sb.WriteString(fmt.Sprintf("Forwarding: localhost:%d -> %d\n", session.LocalPort, session.RemotePort))
+	fmt.Fprintf(&sb, "Forwarding: localhost:%d -> %d\n", session.LocalPort, session.RemotePort)
 	sb.WriteString(strings.Repeat("-", 40) + "\n")
-	sb.WriteString(fmt.Sprintf("Access via: http://localhost:%d\n", session.LocalPort))
+	fmt.Fprintf(&sb, "Access via: http://localhost:%d\n", session.LocalPort)
 	return sb.String()
 }
 
@@ -221,8 +221,8 @@ func formatPortForwardList(sessions []*cluster.PortForwardSession) string {
 	var sb strings.Builder
 	sb.WriteString("Active Port Forwards:\n")
 	sb.WriteString(strings.Repeat("-", 80) + "\n")
-	sb.WriteString(fmt.Sprintf("%-10s %-15s %-25s %-15s %s\n",
-		"ID", "NAMESPACE", "TARGET", "POD", "PORTS"))
+	fmt.Fprintf(&sb, "%-10s %-15s %-25s %-15s %s\n",
+		"ID", "NAMESPACE", "TARGET", "POD", "PORTS")
 	sb.WriteString(strings.Repeat("-", 80) + "\n")
 
 	for _, session := range sessions {
@@ -234,14 +234,13 @@ func formatPortForwardList(sessions []*cluster.PortForwardSession) string {
 		if len(targetDisplay) > 25 {
 			targetDisplay = targetDisplay[:22] + "..."
 		}
-		sb.WriteString(fmt.Sprintf("%-10s %-15s %-25s %-15s %d:%d\n",
+		fmt.Fprintf(&sb, "%-10s %-15s %-25s %-15s %d:%d\n",
 			session.ID,
 			session.Namespace,
 			targetDisplay,
 			podDisplay,
 			session.LocalPort,
-			session.RemotePort,
-		))
+			session.RemotePort)
 	}
 
 	return sb.String()


### PR DESCRIPTION
## Summary

Adds the Streamable HTTP transport (MCP spec 2025-03-26) at `/mcp` alongside the existing legacy SSE transport.

- New: `kai.Server.ServeStreamableHTTP(addr)` using `mcp-go`'s `server.NewStreamableHTTPServer`.
- Refactor: shared `registerOpsEndpoints` and `runHTTP` helpers used by both HTTP transports — no behavioural change to SSE path.
- CLI: `--transport=streamable-http` (or `http`) selects the new transport. `--transport=sse` is accepted as a deprecated alias of `sse-legacy` (logs a warning). Unknown values now return a clear error instead of silently falling back to stdio.
- README updates intentionally deferred to avoid conflict with #108.

## Why

The HTTP+SSE transport (two endpoints, `/sse` + `/message`) was deprecated in spec 2025-03-26. Modern clients (Inspector ≥ 0.10, Claude.ai web) expect a single `/mcp` endpoint with `Mcp-Session-Id` resumption. SSE stays available behind `sse-legacy` for one release cycle.

## Stacked on

Based on `feat/tool-annotations` (#116). Merge order: #114 → #115 → #116 → this.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] Manual: `kai --transport=streamable-http` then `npx @modelcontextprotocol/inspector http://localhost:8080/mcp`