### PR TITLE
fix(lint): extract "starting server" log message into a constant

### DIFF
--- a/cmd/kai/main.go
+++ b/cmd/kai/main.go
@@ -16,6 +16,8 @@ import (
 	"github.com/basebandit/kai/tools"
 )
 
+const startingServerMsg = "starting server"
+
 var (
 	version = "dev"
 	commit  = "none"
@@ -106,7 +108,7 @@ func main() {
 	go func() {
 		switch transport {
 		case "streamable-http", "http":
-			logger.Info("starting server",
+			logger.Info(startingServerMsg,
 				slog.String("transport", "streamable-http"),
 				slog.String("address", sseAddr),
 			)
@@ -115,13 +117,13 @@ func main() {
 			logger.Warn("transport \"sse\" is deprecated; use \"sse-legacy\" or migrate to \"streamable-http\"")
 			fallthrough
 		case "sse-legacy":
-			logger.Info("starting server",
+			logger.Info(startingServerMsg,
 				slog.String("transport", "sse-legacy"),
 				slog.String("address", sseAddr),
 			)
 			errChan <- s.ServeSSE(sseAddr)
 		case "stdio", "":
-			logger.Info("starting server",
+			logger.Info(startingServerMsg,
 				slog.String("transport", "stdio"),
 			)
 			errChan <- s.Serve()


### PR DESCRIPTION
## Summary
- Extracts the duplicated `"starting server"` log message in `cmd/kai/main.go` into a package-level `startingServerMsg` constant.

## Why
SonarCloud flagged the string as duplicated 3× in the transport-dispatch `switch` (one per transport). A constant keeps the call sites aligned and removes the duplication. See [SonarCloud issue](https://sonarcloud.io/project/issues?id=basebandit_kai&issues=AZ4blpwK8bS0tmnOVIBt&open=AZ4blpwK8bS0tmnOVIBt).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`