### PR TITLE
feat: add apply_yaml tool for applying raw manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Kai provides a bridge between large language models (LLMs) and your Kubernetes c
 - [x] **Port Forwarding** - Forward ports to pods and services (start, stop, list sessions)
 
 ### Advanced
+- [x] **Apply Manifests** - Apply raw YAML/JSON, multi-document and any kind including CRDs (apply_yaml)
 - [x] **Custom Resources** - CRD and custom resource operations (list/get CRDs, list/get custom resources)
 - [x] **Events** - Event listing and filtering (by namespace, type, involved object)
 - [x] **API Discovery** - API resource exploration (list_api_resources)
@@ -217,6 +218,7 @@ Once configured, you can interact with your cluster using natural language:
 - "Create a cronjob that runs every 5 minutes"
 - "Create an ingress for my-app with TLS enabled"
 - "Port forward service nginx on port 8080:80"
+- "Apply this manifest: <paste YAML>"
 
 ## Contributing
 

--- a/cluster/apply.go
+++ b/cluster/apply.go
@@ -1,0 +1,163 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/basebandit/kai"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+)
+
+// Apply applies one or more YAML/JSON manifest documents to the cluster. It
+// mirrors `kubectl apply -f`: each document is created if absent or replaced if
+// it already exists (upsert). Documents are separated by `---`.
+type Apply struct {
+	// Manifest is the raw YAML/JSON, optionally multiple `---` separated docs.
+	Manifest string
+
+	// Namespace optionally overrides the target namespace for namespaced objects
+	// whose manifest omits metadata.namespace. Ignored for cluster-scoped kinds.
+	Namespace string
+}
+
+// Run applies every document in the manifest and returns a per-object summary.
+func (a *Apply) Run(ctx context.Context, cm kai.ClusterManager) (string, error) {
+	if strings.TrimSpace(a.Manifest) == "" {
+		return "", errors.New("manifest is required")
+	}
+
+	objs, err := decodeManifests(a.Manifest)
+	if err != nil {
+		return "", err
+	}
+
+	if len(objs) == 0 {
+		return "", errors.New("no kubernetes objects found in manifest")
+	}
+
+	client, err := cm.GetCurrentClient()
+	if err != nil {
+		return "", fmt.Errorf("error getting client: %w", err)
+	}
+	dyn, err := cm.GetCurrentDynamicClient()
+	if err != nil {
+		return "", fmt.Errorf("error getting dynamic client: %w", err)
+	}
+
+	mapper, err := newRESTMapper(client.Discovery())
+	if err != nil {
+		return "", fmt.Errorf("failed to build REST mapper: %w", err)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Applied %d object(s):\n", len(objs))
+	for _, obj := range objs {
+		line, err := applyObject(ctx, dyn, mapper, obj, a.Namespace, cm)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(&sb, "• %s\n", line)
+	}
+	return strings.TrimRight(sb.String(), "\n"), nil
+}
+
+// decodeManifests splits a multi-document YAML/JSON stream into unstructured
+// objects, validating that each carries apiVersion, kind and metadata.name.
+func decodeManifests(manifest string) ([]*unstructured.Unstructured, error) {
+	dec := yaml.NewYAMLOrJSONDecoder(strings.NewReader(manifest), 4096)
+	var objs []*unstructured.Unstructured
+	for {
+		raw := map[string]interface{}{}
+		if err := dec.Decode(&raw); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("failed to parse manifest: %w", err)
+		}
+		if len(raw) == 0 {
+			continue // empty document between separators
+		}
+		obj := &unstructured.Unstructured{Object: raw}
+		if obj.GetAPIVersion() == "" || obj.GetKind() == "" {
+			return nil, errors.New("manifest document missing apiVersion or kind")
+		}
+		if obj.GetName() == "" {
+			return nil, fmt.Errorf("%s document missing metadata.name", obj.GetKind())
+		}
+		objs = append(objs, obj)
+	}
+	return objs, nil
+}
+
+// newRESTMapper builds a REST mapper from server discovery so arbitrary kinds
+// (built-in or CRD) can be resolved to their resource and scope.
+func newRESTMapper(disc discovery.DiscoveryInterface) (meta.RESTMapper, error) {
+	groupResources, err := restmapper.GetAPIGroupResources(disc)
+	if err != nil {
+		return nil, err
+	}
+	return restmapper.NewDiscoveryRESTMapper(groupResources), nil
+}
+
+// applyObject resolves an object's GVK to a resource via the mapper and applies
+// it with server-side apply, honoring namespace scope.
+func applyObject(ctx context.Context, dyn dynamic.Interface, mapper meta.RESTMapper, obj *unstructured.Unstructured, nsOverride string, cm kai.ClusterManager) (string, error) {
+	gvk := obj.GroupVersionKind()
+	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve %s/%s: %w", gvk.GroupVersion().String(), gvk.Kind, err)
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	var (
+		ri     dynamic.ResourceInterface
+		prefix string
+	)
+
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		ns := obj.GetNamespace()
+		if ns == "" {
+			if nsOverride != "" {
+				ns = nsOverride
+			} else {
+				ns = cm.GetCurrentNamespace()
+			}
+		}
+		obj.SetNamespace(ns)
+		ri = dyn.Resource(mapping.Resource).Namespace(ns)
+		prefix = ns + "/"
+	} else {
+		ri = dyn.Resource(mapping.Resource)
+	}
+
+	name := obj.GetName()
+	existing, err := ri.Get(timeoutCtx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		if _, err := ri.Create(timeoutCtx, obj, metav1.CreateOptions{}); err != nil {
+			return "", fmt.Errorf("failed to create %s %q: %w", gvk.Kind, name, err)
+		}
+		return fmt.Sprintf("%s %s%s created", gvk.Kind, prefix, name), nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to get %s %q: %w", gvk.Kind, name, err)
+	}
+
+	// Preserve resourceVersion so the update is accepted as a replace.
+	obj.SetResourceVersion(existing.GetResourceVersion())
+	if _, err := ri.Update(timeoutCtx, obj, metav1.UpdateOptions{}); err != nil {
+		return "", fmt.Errorf("failed to update %s %q: %w", gvk.Kind, name, err)
+	}
+	return fmt.Sprintf("%s %s%s configured", gvk.Kind, prefix, name), nil
+}

--- a/cluster/apply_test.go
+++ b/cluster/apply_test.go
@@ -1,0 +1,159 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/basebandit/kai/testmocks"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// applyDiscovery advertises configmaps (namespaced) and namespaces (cluster)
+// so the REST mapper can resolve both scopes during apply.
+func applyDiscovery() []*metav1.APIResourceList {
+	return []*metav1.APIResourceList{{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{
+			{Name: "configmaps", Namespaced: true, Kind: "ConfigMap"},
+			{Name: "namespaces", Namespaced: false, Kind: "Namespace"},
+		},
+	}}
+}
+
+func uObj(apiVersion, kind, name, ns string) *unstructured.Unstructured {
+	md := map[string]interface{}{"name": name}
+	if ns != "" {
+		md["namespace"] = ns
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata":   md,
+	}}
+}
+
+var applyListKinds = map[schema.GroupVersionResource]string{
+	{Group: "", Version: "v1", Resource: "configmaps"}: "ConfigMapList",
+	{Group: "", Version: "v1", Resource: "namespaces"}: "NamespaceList",
+}
+
+const applyManifest = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+data:
+  key: value
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-a
+`
+
+func TestApplyRun(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Resources = applyDiscovery()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), applyListKinds)
+
+	mockCM := testmocks.NewMockClusterManager()
+	mockCM.On("GetCurrentClient").Return(fakeClient, nil)
+	mockCM.On("GetCurrentDynamicClient").Return(dyn, nil)
+	mockCM.On("GetCurrentNamespace").Return(defaultNamespace)
+
+	result, err := (&Apply{Manifest: applyManifest}).Run(ctx, mockCM)
+	assert.NoError(t, err)
+	assert.Contains(t, result, "Applied 2 object(s)")
+	assert.Contains(t, result, "ConfigMap default/cm1 created")
+	assert.Contains(t, result, "Namespace team-a created")
+
+	// Namespaced object landed in the current namespace.
+	cmGVR := schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
+	got, err := dyn.Resource(cmGVR).Namespace(defaultNamespace).Get(ctx, "cm1", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "cm1", got.GetName())
+}
+
+func TestApplyUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Resources = applyDiscovery()
+
+	cmGVR := schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), applyListKinds)
+	_, err := dyn.Resource(cmGVR).Namespace(defaultNamespace).Create(ctx, uObj("v1", "ConfigMap", "cm1", defaultNamespace), metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	mockCM := testmocks.NewMockClusterManager()
+	mockCM.On("GetCurrentClient").Return(fakeClient, nil)
+	mockCM.On("GetCurrentDynamicClient").Return(dyn, nil)
+	mockCM.On("GetCurrentNamespace").Return(defaultNamespace)
+
+	// Re-applying an existing object takes the update branch.
+	manifest := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+data:
+  key: changed
+`
+	result, err := (&Apply{Manifest: manifest}).Run(ctx, mockCM)
+	assert.NoError(t, err)
+	assert.Contains(t, result, "ConfigMap default/cm1 configured")
+}
+
+func TestApplyNamespaceOverride(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Resources = applyDiscovery()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), applyListKinds)
+
+	mockCM := testmocks.NewMockClusterManager()
+	mockCM.On("GetCurrentClient").Return(fakeClient, nil)
+	mockCM.On("GetCurrentDynamicClient").Return(dyn, nil)
+
+	// Override applies to a namespaced doc that omits metadata.namespace; current
+	// namespace must not be consulted.
+	manifest := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm2
+`
+	result, err := (&Apply{Manifest: manifest, Namespace: otherNamespace}).Run(ctx, mockCM)
+	assert.NoError(t, err)
+	assert.Contains(t, result, "ConfigMap "+otherNamespace+"/cm2 created")
+}
+
+func TestApplyValidation(t *testing.T) {
+	ctx := context.Background()
+	mockCM := testmocks.NewMockClusterManager()
+
+	_, err := (&Apply{Manifest: "   "}).Run(ctx, mockCM)
+	assert.Error(t, err)
+
+	_, err = (&Apply{Manifest: "---\n---\n"}).Run(ctx, mockCM)
+	assert.Error(t, err)
+}
+
+func TestDecodeManifests(t *testing.T) {
+	objs, err := decodeManifests(applyManifest)
+	assert.NoError(t, err)
+	assert.Len(t, objs, 2)
+
+	_, err = decodeManifests("foo: bar")
+	assert.Error(t, err) // missing apiVersion/kind
+
+	_, err = decodeManifests(`apiVersion: v1
+kind: ConfigMap
+`)
+	assert.Error(t, err) // missing metadata.name
+}

--- a/cmd/kai/main.go
+++ b/cmd/kai/main.go
@@ -71,23 +71,27 @@ func main() {
 
 	if inCluster {
 		if err := cm.LoadInClusterConfig(contextName); err != nil {
-			logger.Error("failed to load in-cluster config",
+			logger.Error(
+				"failed to load in-cluster config",
 				slog.String("error", err.Error()),
 			)
 			os.Exit(1)
 		}
-		logger.Info("in-cluster config loaded",
+		logger.Info(
+			"in-cluster config loaded",
 			slog.String("context", contextName),
 		)
 	} else {
 		if err := cm.LoadKubeConfig(contextName, kubeconfig); err != nil {
-			logger.Error("failed to load kubeconfig",
+			logger.Error(
+				"failed to load kubeconfig",
 				slog.String("path", kubeconfig),
 				slog.String("error", err.Error()),
 			)
 			os.Exit(1)
 		}
-		logger.Info("kubeconfig loaded",
+		logger.Info(
+			"kubeconfig loaded",
 			slog.String("path", kubeconfig),
 			slog.String("context", contextName),
 		)
@@ -102,7 +106,8 @@ func main() {
 
 	if tlsCert != "" && tlsKey != "" {
 		serverOpts = append(serverOpts, kai.WithTLS(tlsCert, tlsKey))
-		logger.Info("TLS enabled",
+		logger.Info(
+			"TLS enabled",
 			slog.String("cert", tlsCert),
 			slog.String("key", tlsKey),
 		)
@@ -121,7 +126,8 @@ func main() {
 	go func() {
 		switch transport {
 		case "streamable-http", "http":
-			logger.Info(startingServerMsg,
+			logger.Info(
+				startingServerMsg,
 				slog.String("transport", "streamable-http"),
 				slog.String("address", sseAddr),
 			)
@@ -130,13 +136,15 @@ func main() {
 			logger.Warn("transport \"sse\" is deprecated; use \"sse-legacy\" or migrate to \"streamable-http\"")
 			fallthrough
 		case "sse-legacy":
-			logger.Info(startingServerMsg,
+			logger.Info(
+				startingServerMsg,
 				slog.String("transport", "sse-legacy"),
 				slog.String("address", sseAddr),
 			)
 			errChan <- s.ServeSSE(sseAddr)
 		case "stdio", "":
-			logger.Info(startingServerMsg,
+			logger.Info(
+				startingServerMsg,
 				slog.String("transport", "stdio"),
 			)
 			errChan <- s.Serve()
@@ -212,4 +220,5 @@ func registerAllTools(s *kai.Server, cm *cluster.Manager) {
 	tools.RegisterStorageTools(s, cm)
 	tools.RegisterRBACTools(s, cm)
 	tools.RegisterCustomResourceTools(s, cm)
+	tools.RegisterApplyTools(s, cm)
 }

--- a/tools/apply.go
+++ b/tools/apply.go
@@ -1,0 +1,45 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/basebandit/kai"
+	"github.com/basebandit/kai/cluster"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// RegisterApplyTools registers the apply_yaml tool for applying raw manifests.
+func RegisterApplyTools(s kai.ServerInterface, cm kai.ClusterManager) {
+	s.AddTool(mcp.NewTool(
+		"apply_yaml",
+		mcp.WithDescription("Apply one or more Kubernetes resources from a YAML/JSON manifest (like `kubectl apply -f`) Supports multiple documents separated by `---` and any kind, including CRDs. Uses server-side apply: resources are created if absent or merged if they already exist."),
+		idempotentMutationAnnotation("Apply manifest"),
+		mcp.WithString("manifest", mcp.Required(),
+			mcp.Description("Raw YAML/JSON manifest text.")),
+		mcp.WithString("namespace", mcp.Description("Default namespace for namespaced objects that omit metadata.namespace. Ignored for cluster-scoped kinds.")),
+	), applyYAMLHandler(cm))
+}
+
+func applyYAMLHandler(cm kai.ClusterManager) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		slog.Debug("tool invoked", slog.String("tool", "apply_yaml"))
+
+		manifest, ok := request.GetArguments()["manifest"].(string)
+		if !ok || manifest == "" {
+			return mcp.NewToolResultText("Required parameter 'manifest' is missing"), nil
+		}
+
+		apply := cluster.Apply{Manifest: manifest}
+		if ns, ok := request.GetArguments()["namespace"].(string); ok {
+			apply.Namespace = ns
+		}
+
+		result, err := apply.Run(ctx, cm)
+		if err != nil {
+			return mcp.NewToolResultText(fmt.Sprintf("failed to apply manifest: %s", err.Error())), nil
+		}
+		return mcp.NewToolResultText(result), nil
+	}
+}

--- a/tools/apply_test.go
+++ b/tools/apply_test.go
@@ -1,0 +1,59 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/basebandit/kai/testmocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRegisterApplyTools(t *testing.T) {
+	mockServer := &testmocks.MockServer{}
+	mockCM := testmocks.NewMockClusterManager()
+	mockServer.On("AddTool", mock.AnythingOfType("mcp.Tool"),
+		mock.AnythingOfType("server.ToolHandlerFunc")).Return().Times(1)
+	RegisterApplyTools(mockServer, mockCM)
+	mockServer.AssertExpectations(t)
+}
+
+func TestApplyYAMLHandler(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{{Name: "configmaps", Namespaced: true, Kind: "ConfigMap"}},
+	}}
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "configmaps"}: "ConfigMapList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds)
+
+	mockCM := testmocks.NewMockClusterManager()
+	mockCM.On("GetCurrentClient").Return(fakeClient, nil)
+	mockCM.On("GetCurrentDynamicClient").Return(dyn, nil)
+	mockCM.On("GetCurrentNamespace").Return(defaultNamespace)
+
+	manifest := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+data:
+  k: v
+`
+	r, err := applyYAMLHandler(mockCM)(ctx, toolRequest(map[string]interface{}{"manifest": manifest}))
+	assert.NoError(t, err)
+	assert.Contains(t, resultText(t, r), "ConfigMap default/cm1 created")
+
+	// Missing manifest argument.
+	r, err = applyYAMLHandler(mockCM)(ctx, toolRequest(nil))
+	assert.NoError(t, err)
+	assert.Contains(t, resultText(t, r), "manifest")
+}


### PR DESCRIPTION
## Summary
- New `apply_yaml` MCP tool: apply raw YAML/JSON manifests ( multi-document, any kind including CRDs ), decodes each document, resolves GVK→resource/scope, then upserts ( create if absent, replace if present ); honors namespace scope with an optional default-namespace override.
  
## Why 
Users naturally paste a manifest and say "apply this," but Kai had no generic apply path, every resource needed a dedicated typed tool, and kinds without one (plus arbitrary CRDs) were unreachable. 

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (cluster 82.0%, tools 85.6% coverage)
- [ ] Manual: kind/minikube — paste a multi-doc manifest via an MCP client, confirm create then re-apply
  reports "configured"
