### PR TITLE
Chore/dockerize for standalone deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# VCS and CI
+.git
+.github
+
+# Local binaries and build output
+bin
+dist
+
+# Tests, mocks, and coverage artifacts
+**/*_test.go
+testmocks
+*.out
+*.html
+
+# Docs, assets, and editor/tooling config
+*.md
+*.png
+*.jpg
+.claude
+.vscode
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,12 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 
-COPY . .
+# Copy only the source needed to build the binary (no recursive context copy).
+COPY interfaces.go server.go types.go ./
+COPY cluster/ cluster/
+COPY tools/ tools/
+COPY cmd/ cmd/
+
 ARG VERSION=dev
 ARG COMMIT=none
 ARG DATE=unknown

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM --platform=$BUILDPLATFORM golang:1.25.5 AS build
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+ARG VERSION=dev
+ARG COMMIT=none
+ARG DATE=unknown
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
+  -trimpath \
+  -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
+  -o /kai ./cmd/kai
+
+FROM gcr.io/distroless/static:nonroot
+
+EXPOSE 8080
+
+USER nonroot:nonroot
+
+COPY --from=build /kai /kai
+
+ENTRYPOINT [ "/kai" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+# Pass IMAGE on the command line, e.g. make image IMAGE=youruser/kai
+IMAGE     ?=
+VERSION   ?= $(shell git describe --tags --always --dirty)
+COMMIT    := $(shell git rev-parse --short HEAD)
+DATE      := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+PLATFORMS ?= linux/amd64,linux/arm64
+
+.PHONY: build test lint image image-push
+
+build:
+	go build -o bin/kai ./cmd/kai
+
+test:
+	go test -race -coverprofile=coverage.out ./...
+
+lint:
+	golangci-lint run
+
+# Build a local image for the current architecture.
+image:
+	@test -n "$(IMAGE)" || (echo "set IMAGE, e.g. make image IMAGE=youruser/kai"; exit 1)
+	docker build \
+	  --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --build-arg DATE=$(DATE) \
+	  -t $(IMAGE):$(VERSION) .
+
+# Build amd64 + arm64 and push to the registry.
+image-push:
+	@test -n "$(IMAGE)" || (echo "set IMAGE, e.g. make image-push IMAGE=youruser/kai"; exit 1)
+	docker buildx build --platform $(PLATFORMS) \
+	  --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --build-arg DATE=$(DATE) \
+	  -t $(IMAGE):$(VERSION) -t $(IMAGE):latest --push .

--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ The server connects to your current kubectl context by default. Ensure you have 
 go install github.com/basebandit/kai/cmd/kai@latest
 ```
 
+### Container image
+
+A multi-arch image (linux/amd64, linux/arm64) is published on Docker Hub:
+
+```sh
+docker pull cyclon/kai:v1.0.0
+docker run --rm cyclon/kai:v1.0.0 -version
+```
+
 ## CLI Options
 
 ```
@@ -199,7 +208,7 @@ spec:
       serviceAccountName: kai
       containers:
         - name: kai
-          image: ghcr.io/basebandit/kai:latest
+          image: cyclon/kai:v1.0.0
           args: ["-in-cluster", "-transport=sse", "-sse-addr=:8080"]
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary
- Add multi-stage `Dockerfile` (distroless nonroot, multi-arch).
-  Add `.dockerignore` and a `Makefile` (`build`/`test`/`lint`/`image`/`image-push`).

## Why
We needed a build path to ship Kai as a container, runnable anywhere (Kubernetes, EC2, plain Docker host),  with version stamping matching the release binary from the goreleaser ldflags

## Test plan
- [x] `docker build` — `kai -version` prints v1.0.0
- [x] `docker buildx --platform linux/amd64,linux/arm64 --push` — both arches pushed
- [ ] Manual: run the container on a host and exercise a tool over `/mcp`