### PR TITLE
Feat/delete tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Kai provides a bridge between large language models (LLMs) and your Kubernetes c
 - [x] **Port Forwarding** - Forward ports to pods and services (start, stop, list sessions)
 
 ### Advanced
-- [x] **Apply Manifests** - Apply raw YAML/JSON, multi-document and any kind including CRDs (apply_yaml)
-- [x] **Custom Resources** - CRD and custom resource operations (list/get CRDs, list/get custom resources)
+- [x] **Apply/Delete Manifests** - Apply or delete raw YAML/JSON, multi-document and any kind including CRDs (apply_yaml, delete_yaml)
+- [x] **Custom Resources** - CRD and custom resource operations (list/get CRDs, list/get/delete custom resources)
 - [x] **Events** - Event listing and filtering (by namespace, type, involved object)
 - [x] **API Discovery** - API resource exploration (list_api_resources)
 

--- a/cluster/customresource.go
+++ b/cluster/customresource.go
@@ -200,6 +200,37 @@ func (c *CustomResource) Get(ctx context.Context, cm kai.ClusterManager) (string
 	return strings.TrimRight(sb.String(), "\n"), nil
 }
 
+// Delete removes a single custom resource instance identified by
+// group/version/resource/name. It tries the namespaced scope first, then falls
+// back to cluster scope, mirroring Get.
+func (c *CustomResource) Delete(ctx context.Context, cm kai.ClusterManager) (string, error) {
+	if c.Version == "" || c.Resource == "" || c.Name == "" {
+		return "", fmt.Errorf("version, resource and name are required")
+	}
+	dyn, err := cm.GetCurrentDynamicClient()
+	if err != nil {
+		return "", fmt.Errorf("error getting dynamic client: %w", err)
+	}
+
+	gvr := schema.GroupVersionResource{Group: c.Group, Version: c.Version, Resource: c.Resource}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	ns := c.Namespace
+	if ns == "" {
+		ns = cm.GetCurrentNamespace()
+	}
+	delErr := dyn.Resource(gvr).Namespace(ns).Delete(timeoutCtx, c.Name, metav1.DeleteOptions{})
+	if delErr != nil {
+		// Retry cluster-scoped if the namespaced delete failed.
+		if err = dyn.Resource(gvr).Delete(timeoutCtx, c.Name, metav1.DeleteOptions{}); err != nil {
+			return "", fmt.Errorf("failed to delete custom resource %q: %w", c.Name, delErr)
+		}
+	}
+	return fmt.Sprintf("Custom resource %q deleted successfully", c.Name), nil
+}
+
 // ListAPIResources lists the server's preferred API resources (discovery).
 func (c *CustomResource) ListAPIResources(ctx context.Context, cm kai.ClusterManager) (string, error) {
 	client, err := cm.GetCurrentClient()

--- a/cluster/customresource_test.go
+++ b/cluster/customresource_test.go
@@ -106,9 +106,17 @@ func TestCustomResourceInstances(t *testing.T) {
 	assert.Contains(t, get, "Widget: w1")
 	assert.Contains(t, get, "phase")
 
+	del, err := (&CustomResource{Group: "example.com", Version: "v1", Resource: "widgets", Name: "w1"}).Delete(ctx, mockCM)
+	assert.NoError(t, err)
+	assert.Contains(t, del, "deleted successfully")
+	_, err = dyn.Resource(widgetGVR).Namespace(defaultNamespace).Get(ctx, "w1", metav1.GetOptions{})
+	assert.Error(t, err)
+
 	_, err = (&CustomResource{Version: "v1"}).List(ctx, mockCM, false)
 	assert.Error(t, err)
 	_, err = (&CustomResource{Resource: "widgets"}).Get(ctx, mockCM)
+	assert.Error(t, err)
+	_, err = (&CustomResource{Resource: "widgets"}).Delete(ctx, mockCM)
 	assert.Error(t, err)
 }
 

--- a/cluster/delete.go
+++ b/cluster/delete.go
@@ -1,0 +1,109 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/basebandit/kai"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// Delete removes one or more YAML/JSON manifest documents from the cluster. It
+// mirrors `kubectl delete -f`: every document is resolved to its resource and
+// deleted. Documents are separated by `---`.
+type Delete struct {
+	// Manifest is the raw YAML/JSON, optionally multiple `---` separated docs.
+	Manifest string
+	// Namespace optionally overrides the target namespace for namespaced objects
+	// whose manifest omits metadata.namespace. Ignored for cluster-scoped kinds.
+	Namespace string
+}
+
+// Run deletes every document in the manifest and returns a per-object summary.
+func (d *Delete) Run(ctx context.Context, cm kai.ClusterManager) (string, error) {
+	if strings.TrimSpace(d.Manifest) == "" {
+		return "", errors.New("manifest is required")
+	}
+
+	objs, err := decodeManifests(d.Manifest)
+	if err != nil {
+		return "", err
+	}
+	if len(objs) == 0 {
+		return "", errors.New("no kubernetes objects found in manifest")
+	}
+
+	client, err := cm.GetCurrentClient()
+	if err != nil {
+		return "", fmt.Errorf("error getting client: %w", err)
+	}
+	dyn, err := cm.GetCurrentDynamicClient()
+	if err != nil {
+		return "", fmt.Errorf("error getting dynamic client: %w", err)
+	}
+
+	mapper, err := newRESTMapper(client.Discovery())
+	if err != nil {
+		return "", fmt.Errorf("failed to build REST mapper: %w", err)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Deleted %d object(s):\n", len(objs))
+	for _, obj := range objs {
+		line, err := deleteObject(ctx, dyn, mapper, obj, d.Namespace, cm)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(&sb, "• %s\n", line)
+	}
+	return strings.TrimRight(sb.String(), "\n"), nil
+}
+
+// deleteObject resolves an object's GVK to a resource via the mapper and deletes
+// it, honoring namespace scope. A missing object is reported, not treated as an
+// error, so deleting an already-gone manifest is idempotent.
+func deleteObject(ctx context.Context, dyn dynamic.Interface, mapper meta.RESTMapper, obj *unstructured.Unstructured, nsOverride string, cm kai.ClusterManager) (string, error) {
+	gvk := obj.GroupVersionKind()
+	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve %s/%s: %w", gvk.GroupVersion().String(), gvk.Kind, err)
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	var (
+		ri     dynamic.ResourceInterface
+		prefix string
+	)
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		ns := obj.GetNamespace()
+		if ns == "" {
+			if nsOverride != "" {
+				ns = nsOverride
+			} else {
+				ns = cm.GetCurrentNamespace()
+			}
+		}
+		ri = dyn.Resource(mapping.Resource).Namespace(ns)
+		prefix = ns + "/"
+	} else {
+		ri = dyn.Resource(mapping.Resource)
+	}
+
+	name := obj.GetName()
+	err = ri.Delete(timeoutCtx, name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return fmt.Sprintf("%s %s%s not found (already deleted)", gvk.Kind, prefix, name), nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to delete %s %q: %w", gvk.Kind, name, err)
+	}
+	return fmt.Sprintf("%s %s%s deleted", gvk.Kind, prefix, name), nil
+}

--- a/cluster/delete_test.go
+++ b/cluster/delete_test.go
@@ -1,0 +1,78 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/basebandit/kai/testmocks"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDeleteRun(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Resources = applyDiscovery()
+
+	cmGVR := schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
+	nsGVR := schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), applyListKinds)
+	_, err := dyn.Resource(cmGVR).Namespace(defaultNamespace).Create(ctx, uObj("v1", "ConfigMap", "cm1", defaultNamespace), metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = dyn.Resource(nsGVR).Create(ctx, uObj("v1", "Namespace", "team-a", ""), metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	mockCM := testmocks.NewMockClusterManager()
+	mockCM.On("GetCurrentClient").Return(fakeClient, nil)
+	mockCM.On("GetCurrentDynamicClient").Return(dyn, nil)
+	mockCM.On("GetCurrentNamespace").Return(defaultNamespace)
+
+	result, err := (&Delete{Manifest: applyManifest}).Run(ctx, mockCM)
+	assert.NoError(t, err)
+	assert.Contains(t, result, "Deleted 2 object(s)")
+	assert.Contains(t, result, "ConfigMap default/cm1 deleted")
+	assert.Contains(t, result, "Namespace team-a deleted")
+
+	// Object is gone.
+	_, err = dyn.Resource(cmGVR).Namespace(defaultNamespace).Get(ctx, "cm1", metav1.GetOptions{})
+	assert.Error(t, err)
+}
+
+func TestDeleteNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Resources = applyDiscovery()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), applyListKinds)
+
+	mockCM := testmocks.NewMockClusterManager()
+	mockCM.On("GetCurrentClient").Return(fakeClient, nil)
+	mockCM.On("GetCurrentDynamicClient").Return(dyn, nil)
+	mockCM.On("GetCurrentNamespace").Return(defaultNamespace)
+
+	// Deleting an absent object is reported, not errored (idempotent).
+	manifest := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ghost
+`
+	result, err := (&Delete{Manifest: manifest}).Run(ctx, mockCM)
+	assert.NoError(t, err)
+	assert.Contains(t, result, "not found (already deleted)")
+}
+
+func TestDeleteValidation(t *testing.T) {
+	ctx := context.Background()
+	mockCM := testmocks.NewMockClusterManager()
+
+	_, err := (&Delete{Manifest: "   "}).Run(ctx, mockCM)
+	assert.Error(t, err)
+
+	_, err = (&Delete{Manifest: "---\n---\n"}).Run(ctx, mockCM)
+	assert.Error(t, err)
+}

--- a/cmd/kai/main.go
+++ b/cmd/kai/main.go
@@ -221,4 +221,5 @@ func registerAllTools(s *kai.Server, cm *cluster.Manager) {
 	tools.RegisterRBACTools(s, cm)
 	tools.RegisterCustomResourceTools(s, cm)
 	tools.RegisterApplyTools(s, cm)
+	tools.RegisterDeleteTools(s, cm)
 }

--- a/tools/customresource.go
+++ b/tools/customresource.go
@@ -43,6 +43,16 @@ func RegisterCustomResourceTools(s kai.ServerInterface, cm kai.ClusterManager) {
 		mcp.WithString("namespace", mcp.Description("Namespace (defaults to current; ignored for cluster-scoped)")),
 	), getCustomResourceHandler(cm))
 
+	s.AddTool(mcp.NewTool("delete_custom_resource",
+		mcp.WithDescription("Delete a single custom resource instance by group/version/resource/name"),
+		destructiveAnnotation("Delete custom resource"),
+		mcp.WithString("group", mcp.Description("API group (e.g. 'example.com'; empty for core)")),
+		mcp.WithString("version", mcp.Required(), mcp.Description("API version (e.g. 'v1')")),
+		mcp.WithString("resource", mcp.Required(), mcp.Description("Plural resource name (e.g. 'widgets')")),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Name of the resource instance")),
+		mcp.WithString("namespace", mcp.Description("Namespace (defaults to current; ignored for cluster-scoped)")),
+	), deleteCustomResourceHandler(cm))
+
 	s.AddTool(mcp.NewTool("list_api_resources",
 		mcp.WithDescription("List the server's preferred API resources (like 'kubectl api-resources')"),
 		readOnlyAnnotation("List API resources"),
@@ -131,6 +141,26 @@ func getCustomResourceHandler(cm kai.ClusterManager) func(ctx context.Context, r
 		result, err := cr.Get(ctx, cm)
 		if err != nil {
 			return mcp.NewToolResultText(fmt.Sprintf("Failed to get custom resource: %s", err.Error())), nil
+		}
+		return mcp.NewToolResultText(result), nil
+	}
+}
+
+func deleteCustomResourceHandler(cm kai.ClusterManager) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		slog.Debug("tool invoked", slog.String("tool", "delete_custom_resource"))
+		cr, errResult := customResourceFromRequest(request)
+		if errResult != nil {
+			return errResult, nil
+		}
+		name, errResult := requireName(request)
+		if errResult != nil {
+			return errResult, nil
+		}
+		cr.Name = name
+		result, err := cr.Delete(ctx, cm)
+		if err != nil {
+			return mcp.NewToolResultText(fmt.Sprintf("Failed to delete custom resource: %s", err.Error())), nil
 		}
 		return mcp.NewToolResultText(result), nil
 	}

--- a/tools/customresource_test.go
+++ b/tools/customresource_test.go
@@ -27,7 +27,7 @@ var (
 func TestRegisterCustomResourceTools(t *testing.T) {
 	mockServer := &testmocks.MockServer{}
 	mockCM := testmocks.NewMockClusterManager()
-	mockServer.On("AddTool", mock.AnythingOfType("mcp.Tool"), mock.AnythingOfType("server.ToolHandlerFunc")).Return().Times(5)
+	mockServer.On("AddTool", mock.AnythingOfType("mcp.Tool"), mock.AnythingOfType("server.ToolHandlerFunc")).Return().Times(6)
 	RegisterCustomResourceTools(mockServer, mockCM)
 	mockServer.AssertExpectations(t)
 }
@@ -79,6 +79,12 @@ func TestCustomResourceHandlers(t *testing.T) {
 	}))
 	assert.NoError(t, err)
 	assert.Contains(t, resultText(t, r), "Widget: w1")
+
+	r, err = deleteCustomResourceHandler(mockCM)(ctx, toolRequest(map[string]interface{}{
+		"group": "example.com", "version": "v1", "resource": "widgets", "name": "w1",
+	}))
+	assert.NoError(t, err)
+	assert.Contains(t, resultText(t, r), "deleted successfully")
 
 	// Missing required version.
 	r, err = listCustomResourcesHandler(mockCM)(ctx, toolRequest(map[string]interface{}{"resource": "widgets"}))

--- a/tools/delete.go
+++ b/tools/delete.go
@@ -1,0 +1,46 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/basebandit/kai"
+	"github.com/basebandit/kai/cluster"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// RegisterDeleteTools registers the delete_yaml tool for deleting resources from
+// a raw manifest.
+func RegisterDeleteTools(s kai.ServerInterface, cm kai.ClusterManager) {
+	s.AddTool(mcp.NewTool(
+		"delete_yaml",
+		mcp.WithDescription("Delete one or more Kubernetes resources described by a YAML/JSON manifest (like `kubectl delete -f`). Supports multiple documents separated by `---` and any kind, including CRDs. Objects that are already gone are reported, not errored."),
+		destructiveAnnotation("Delete from manifest"),
+		mcp.WithString("manifest", mcp.Required(),
+			mcp.Description("Raw YAML/JSON manifest text identifying the resources to delete.")),
+		mcp.WithString("namespace", mcp.Description("Default namespace for namespaced objects that omit metadata.namespace. Ignored for cluster-scoped kinds.")),
+	), deleteYAMLHandler(cm))
+}
+
+func deleteYAMLHandler(cm kai.ClusterManager) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		slog.Debug("tool invoked", slog.String("tool", "delete_yaml"))
+
+		manifest, ok := request.GetArguments()["manifest"].(string)
+		if !ok || manifest == "" {
+			return mcp.NewToolResultText("Required parameter 'manifest' is missing"), nil
+		}
+
+		del := cluster.Delete{Manifest: manifest}
+		if ns, ok := request.GetArguments()["namespace"].(string); ok {
+			del.Namespace = ns
+		}
+
+		result, err := del.Run(ctx, cm)
+		if err != nil {
+			return mcp.NewToolResultText(fmt.Sprintf("failed to delete manifest: %s", err.Error())), nil
+		}
+		return mcp.NewToolResultText(result), nil
+	}
+}

--- a/tools/delete_test.go
+++ b/tools/delete_test.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/basebandit/kai/testmocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRegisterDeleteTools(t *testing.T) {
+	mockServer := &testmocks.MockServer{}
+	mockCM := testmocks.NewMockClusterManager()
+	mockServer.On("AddTool", mock.AnythingOfType("mcp.Tool"),
+		mock.AnythingOfType("server.ToolHandlerFunc")).Return().Times(1)
+	RegisterDeleteTools(mockServer, mockCM)
+	mockServer.AssertExpectations(t)
+}
+
+func TestDeleteYAMLHandler(t *testing.T) {
+	ctx := context.Background()
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{{Name: "configmaps", Namespaced: true, Kind: "ConfigMap"}},
+	}}
+	cmGVR := schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
+	listKinds := map[schema.GroupVersionResource]string{cmGVR: "ConfigMapList"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds)
+	_, err := dyn.Resource(cmGVR).Namespace(defaultNamespace).Create(ctx, &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "cm1", "namespace": defaultNamespace},
+	}}, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	mockCM := testmocks.NewMockClusterManager()
+	mockCM.On("GetCurrentClient").Return(fakeClient, nil)
+	mockCM.On("GetCurrentDynamicClient").Return(dyn, nil)
+	mockCM.On("GetCurrentNamespace").Return(defaultNamespace)
+
+	manifest := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+`
+	r, err := deleteYAMLHandler(mockCM)(ctx, toolRequest(map[string]interface{}{"manifest": manifest}))
+	assert.NoError(t, err)
+	assert.Contains(t, resultText(t, r), "ConfigMap default/cm1 deleted")
+
+	// Missing manifest argument.
+	r, err = deleteYAMLHandler(mockCM)(ctx, toolRequest(nil))
+	assert.NoError(t, err)
+	assert.Contains(t, resultText(t, r), "manifest")
+}


### PR DESCRIPTION
## Summary
- Add `delete_yaml` — delete any kind from a YAML/JSON manifest (multi-doc, CRDs included); missing objects
  reported, not errored.
- Add `delete_custom_resource` — delete a CR by group/version/resource/name.

## Why
Kai could create anything (`apply_yaml`) but couldn't delete arbitrary kinds, RBAC/CR tools were read-only. No way to tear down ServiceAccounts, ClusterRoleBindings, or CRD instances it created. These close that gap symmetrically.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (cluster 82.0%, tools 85.6%)
- [ ] Manual: delete a manifest + a CR via MCP inspector after deploy